### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const DB_SETTING_KEY = 'nodebb-plugin-qiniu-file';
-const DB = module.parent.require('./database');
+const DB = module.main.require('./database');
 const qiniu = require('qiniu');
 
 (function (E) {


### PR DESCRIPTION
 [deprecated] requiring core modules with `module.parent.require('./database')` is deprecated. Please use `require.main.require("./src/<module_name>")` instead.